### PR TITLE
cibuild: simplify for new jenkins

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -1,10 +1,18 @@
 #!/bin/bash
-sudo eselect postgresql set 9.2
-sudo make clean && sudo make && sudo make install && sudo make installcheck
-sudo /etc/init.d/postgresql-9.2 stop
-sudo /etc/init.d/postgresql-9.3 start
-sudo eselect postgresql set 9.3
-sudo make clean && sudo make && sudo make install && sudo make installcheck
-sudo /etc/init.d/postgresql-9.3 stop
-sudo /etc/init.d/postgresql-9.2 start
-sudo eselect postgresql set 9.2
+
+case "${HOSTNAME}" in
+vm*)
+    make clean && make && make install && make installcheck REGRESS_OPTS="--port=$PGPORT"
+    ;;
+*)
+    sudo eselect postgresql set 9.2
+    sudo make clean && sudo make && sudo make install && sudo make installcheck
+    sudo /etc/init.d/postgresql-9.2 stop
+    sudo /etc/init.d/postgresql-9.3 start
+    sudo eselect postgresql set 9.3
+    sudo make clean && sudo make && sudo make install && sudo make installcheck
+    sudo /etc/init.d/postgresql-9.3 stop
+    sudo /etc/init.d/postgresql-9.2 start
+    sudo eselect postgresql set 9.2
+    ;;
+esac


### PR DESCRIPTION
1. New jenkins does not require sudo for postgresl extension installs.
2. Pass PGPORT to installcheck so as to run tests under a temporary
postgresql server.

Note this script is invoked 3 times by the jenkins job once for each postgresl
slots 9.4, 9.5 and 9.6. If you want additional postgresql slots to be tested,
please say so.

Note this is not urgent because we have a sed on the new jenkins which takes
care of this.