### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,13 @@ DATA = wltree--2.0.sql wltree--unpackaged--2.0.sql wltree--dummy.sql wltree--dum
 
 REGRESS = wltree
 
+ifdef USE_PGXS
 PG_CONFIG ?= pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
+else
+subdir = contrib/hstore
+top_builddir = ../..
+include $(top_builddir)/src/Makefile.global
+include $(top_srcdir)/contrib/contrib-global.mk
+endif


### PR DESCRIPTION
Allows compiling directly in postgres' source contrib/ folder.
This makes packaging a little bit more convenient.